### PR TITLE
[FEAT] Add more metrics from LLM, new exception from empty results on reports.

### DIFF
--- a/services/register_service.py
+++ b/services/register_service.py
@@ -9,7 +9,14 @@ class Register(BaseModel):
     response: str
     response_time: int
     feedback: str
+    response_time: int ## Tempo total 
+    eval_duration: int ## Tempo gerando resposta
+    load_time: int ## Tempo de carregamento do modelo
+    prompt_tokens: int ## Tokens no prompt
+    prompt_eval_time: int ## Tempo avaliando prompt
+    response_tokens: int ## Tokens na resposta
     util: str
+    retry: bool
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 
@@ -17,7 +24,13 @@ class RegisterLLM(BaseModel):
     area: str
     question: str
     response: str
-    response_time: int
+    response_time: int ## Tempo total 
+    eval_duration: int ## Tempo gerando resposta
+    load_time: int ## Tempo de carregamento do modelo
+    prompt_tokens: int ## Tokens no prompt
+    prompt_eval_time: int ## Tempo avaliando prompt
+    response_tokens: int ## Tokens na resposta
+    retry: bool
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/index.py
+++ b/src/index.py
@@ -16,7 +16,7 @@ from services.mongo_service import MongoService
 app = FastAPI(
     title="Assistant Toolkit",
     description="An API to integrate IBM Discovery with LLM Models and A.I Assistants.",
-    version="2.0.3"
+    version="2.0.4"
 )
 
 app.openapi_version = "3.0.2"
@@ -114,7 +114,6 @@ async def createRegisterLL(request: RegisterLLM, token: str = Depends(oauth2_sch
         register = await register_service.create_register(request.model_dump())
         return register
 
-# TODO: improve this service and add exceptions for empty responses
 @app.get("/analytcs", 
          tags=['Analyzes'],
          name="Gera relatório: Perguntas + Respostas + Feedback",


### PR DESCRIPTION
This pull request introduces the following changes:

## 🚀 **1. [FEAT] Added new LLM metrics**
- Added new metrics to the `RegisterLLM` model and data processing pipeline:
  - `eval_duration`: Time taken to generate the response.
  - `load_time`: Model loading time.
  - `prompt_tokens`: Tokens used in the prompt.
  - `prompt_eval_time`: Time taken to evaluate the prompt.
  - `response_tokens`: Tokens used in the response.

## 🛠️ **2. Exception handling for empty results**
- Implemented validation to return a **404 error** (`HTTPException`) when no entries are found based on the provided criteria in the `analytcs_search` function within `services/analytcs_service.py`.

## 📊 **3. Report generation enhancements**
- Time fields (`response_time`, `eval_duration`, etc.) are now converted from **nanoseconds to seconds** before CSV export.
- Improved error handling during the report generation process.

## 📝 **4. Updates in `index.py`**
- Incremented application version from **2.0.3** to **2.0.4**.