### PR TITLE
[REFACT][FIX] Fix registers and reports: ensure correct timestamp recording and handling

### DIFF
--- a/services/analytcs_service.py
+++ b/services/analytcs_service.py
@@ -3,7 +3,7 @@ from fastapi import HTTPException
 import pandas as pd
 from fastapi.responses import StreamingResponse
 import io
-from datetime import datetime
+from datetime import datetime, timezone, timedelta, time
 from services.mongo_service import MongoService
 
 class AreaEnum(str, Enum):
@@ -17,39 +17,44 @@ class AnalytcsService:
 
     async def analytcs_search(self, start_date, end_date, area):
         try:
-            start_date_str = start_date.isoformat()
-            end_date_str = end_date.isoformat() 
-            start_date_obj = datetime.fromisoformat(start_date_str)
-            end_date_obj = datetime.fromisoformat(end_date_str)
+            # Se start_date/end_date não forem datetime, converte-os usando datetime.combine.
+            if not isinstance(start_date, datetime):
+                start_date_obj = datetime.combine(start_date, time.min)
+            else:
+                start_date_obj = start_date
+
+            if not isinstance(end_date, datetime):
+                end_date_obj = datetime.combine(end_date, time.min)
+            else:
+                end_date_obj = end_date
+
+            # Ajustar para UTC e definir start_date_obj como o começo do dia
+            start_date_obj = start_date_obj.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+            # Definir end_date_obj como o começo do dia e depois somar 1 dia para que a query use $lt
+            end_date_obj = end_date_obj.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc) + timedelta(days=1)
+
+            print(f"Start Date (UTC): {start_date_obj}")
+            print(f"End Date (UTC): {end_date_obj}")
 
             collection_llm = await self.mongo_service.get_collection("analyzesLLM")
             collection_legacy = await self.mongo_service.get_collection("analyzes")
 
-            registers_llm = collection_llm.find({
-                "area": area,
+            query_filter = {
+                "area": area.value if isinstance(area, AreaEnum) else area,
                 "created_at": {
                     "$gte": start_date_obj,
-                    "$lte": end_date_obj
+                    "$lt": end_date_obj  # Usamos $lt para capturar até o início do próximo dia
                 }
-            })
+            }
 
-            registers_legacy = collection_legacy.find({
-                "area": area,
-                "created_at": {
-                    "$gte": start_date_obj,
-                    "$lte": end_date_obj
-                }
-            })
+            print(f"Query: {query_filter}")
 
-            results_llm = []
-            async for document in registers_llm:
-                results_llm.append(document)
+            registers_llm = collection_llm.find(query_filter)
+            registers_legacy = collection_legacy.find(query_filter)
 
-            results_legacy = []
-            async for document in registers_legacy:
-                results_legacy.append(document)
+            results_llm = [doc async for doc in registers_llm]
+            results_legacy = [doc async for doc in registers_legacy]
 
-            # Verifica se há resultados
             if not results_llm and not results_legacy:
                 raise HTTPException(status_code=404, detail="Nenhum registro encontrado para os critérios fornecidos.")
 

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 from services.mongo_service import MongoService
 from pymongo.errors import PyMongoError
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Register(BaseModel):
     area: str
@@ -44,31 +44,40 @@ class RegisterService:
     def __init__(self, mongo_service: MongoService):
         self.mongo_service = mongo_service
 
-    async def create_register(self, register):
+    async def create_register(self, register: dict):
         try:
-            if not register:
-                raise ValueError("Um campo está inválido")
-            
+            if not isinstance(register, dict) or not register:
+                raise ValueError("Os dados do registro são inválidos.")
+
             async with self.mongo_service as mongo:
                 db = await mongo.get_database()
 
-                register['created_at'] = datetime.now()
-                register['updated_at'] = datetime.now()
-                if 'feedback' not in register:
-                    result = await db["analyzesLLM"].insert_one(register)
-                else:
-                    result = await db["analyzes"].insert_one(register)
+                # Se os timestamps forem strings, converter corretamente para UTC
+                for field in ["created_at", "updated_at"]:
+                    if field in register and isinstance(register[field], str):
+                        dt = datetime.fromisoformat(register[field])
+                        if dt.tzinfo is None:  # Se não tem timezone, assumir UTC
+                            dt = dt.replace(tzinfo=timezone.utc)
+                        register[field] = dt
+
+                # Caso os campos não sejam enviados, definir UTC atual
+                register.setdefault("created_at", datetime.now(timezone.utc))
+                register.setdefault("updated_at", datetime.now(timezone.utc))
+
+                # Escolher a coleção correta com base na presença do campo 'feedback'
+                collection_name = "analyzesLLM" if "feedback" not in register else "analyzes"
+                result = await db[collection_name].insert_one(register)
 
                 if not result.acknowledged:
-                    raise Exception("A inserção do registro falhou")
+                    raise Exception("A inserção do registro falhou.")
 
                 return str(result.inserted_id)
-        
+
         except ValueError as ve:
             raise Exception(f"Erro de validação: {str(ve)}")
-        
+
         except PyMongoError as pe:
-            raise Exception(f"Erro ao registrar: {str(pe)}")
-        
+            raise Exception(f"Erro ao registrar no banco de dados: {str(pe)}")
+
         except Exception as e:
             raise Exception(f"Erro ao criar o registro: {str(e)}")

--- a/src/index.py
+++ b/src/index.py
@@ -118,7 +118,12 @@ async def createRegisterLL(request: RegisterLLM, token: str = Depends(oauth2_sch
          tags=['Analyzes'],
          name="Gera relatório: Perguntas + Respostas + Feedback",
          description="Devolve CSV com os registros encontrados conforme query")
-async def analytcs(start_date: date = Query(..., description="Buscar a partir de", example="2024-01-01"), end_date: date = Query(..., description="Buscar até", example="2024-01-01"), area: AreaEnum = Query(...), token: str = Depends(oauth2_scheme)):
+async def analytcs(
+    start_date: date = Query(..., description="Buscar a partir de", example=date.today().isoformat()), 
+    end_date: date = Query(..., description="Buscar até", example=date.today().isoformat()), 
+    area: AreaEnum = Query(...), 
+    token: str = Depends(oauth2_scheme)
+):
     async with MongoService() as mongo_service:
         analytcs_service = AnalytcsService(mongo_service)
         analytcs_res = await analytcs_service.analytcs_search(start_date, end_date, area)


### PR DESCRIPTION
### 🔧 Changes  
- **`services/analytcs_service.py`**  
  - Ensure `start_date` and `end_date` are properly handled as `datetime`.  
  - Set timestamps to UTC and adjust query filtering using `$lt` instead of `$lte`.  
  - Unify queries for `collection_llm` and `collection_legacy`.  

- **`services/register_service.py`**  
  - Validate and convert timestamps to UTC before storing in MongoDB.  
  - Improve error handling and exception messages.  
  - Dynamically select the correct collection (`analyzesLLM` or `analyzes`).  

- **`src/index.py`**  
  - Improve query parameter formatting for `analytcs` endpoint.  
  - Use `date.today().isoformat()` as default example values.  

### 🐛 Fixes  
- Ensure timestamps are correctly stored and queried in UTC.  
- Prevent errors when handling `area` values (enum vs. string).  
- Avoid potential query issues due to incorrect filters.  

### 🚀 How to Test  
1. Query the `/analytcs` endpoint and verify correct date filtering.  
2. Create new registers and check if timestamps are stored in UTC.  
3. Run existing tests to confirm functionality remains intact.  

### ✅ Checklist  
- [x] Code reviewed and manually tested.  
- [x] Ensured compatibility with existing calls.  
- [x] Improved readability and structure.  